### PR TITLE
get rid of KCM, use FILEs only; make clients different

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # NFSv4 + Kerberos in Kubernetes
 
-Kubeadm cluster with NFSv4 + Kerberos authentication using KCM sidecar pattern.
+Kubeadm cluster with NFSv4 + Kerberos authentication.
 
 ## Setup
+
+Setup requires three Ubuntu 24.04 VMs with root access, 4GB RAM, 50GB disk each.
+Single node setup is not supported to avoid taking shortcuts that would not work
+in real world.
 
 ```bash
 # On KDC machine (192.168.1.10):
@@ -19,19 +23,17 @@ make deploy KDC=kdc-192.168.1.10.nip.io NFS=nfs-192.168.1.11.nip.io
 
 # Test everything:
 make test
+
+# Test specific scenarios:
+make test-persistent    # Test data persistence across pod restarts
+make test-renewal      # Test Kerberos renewal lifecycle (~2 hours)
 ```
-
-## Requirements
-
-- Ubuntu 24.04 VMs with ens3 interface
-- Root access, 4GB RAM, 50GB disk per machine
-- Network connectivity between machines
 
 ## Architecture
 
 **Components:**
-- **KDC machine**: Kerberos KDC server (port 88, 8080)
-- **NFS machine**: NFS server with Kerberos (port 2049, sec=krb5)
+- **KDC machine**: Kerberos KDC server
+- **NFS machine**: NFS server with Kerberos
 - **K8s machine**: Kubernetes node with client pods
 
 **Using nip.io for hostnames:**
@@ -46,34 +48,34 @@ make test
 
 ## What Gets Deployed
 
-**Host level:**
-- KDC server: `kdc.example.com` (port 88, 8080)
-- NFS server: `nfs.example.com` (port 2049, sec=krb5)
-- Host keytab: `/etc/krb5.keytab` with NFS service principals
-- KCM daemon: Credential sharing via Unix socket
-- GSS modules + RPC pipefs
-
-**Per-user (3 users: 10002, 10003, 10004):**
+**Per-user (5 users: user id's from 10002 to 10006):**
 - User principals + keytabs from HTTP
 - NFS exports with proper UIDs
-- PV/PVC + Pod (krb5-sidecar + nfs-client)
+- PV/PVC + Pod
+- See `nri.io/kerberos-scenario` annotation for pod scenario
 
 **Sidecar:**
-- User `kinit` + NFS service tickets
-- Credential renewal + KCM integration
+- Credential renewal with FILE-based credential caches
 
 ## Architecture
 
 Host authenticates NFS mount. Containers authenticate file access.
 Auth needs to be in place on the node side when Kubelet mounts the NFS,
-otherwise it is stale mount.
+otherwise it is stale mount. This is dynamically handled by custom NRI plugin,
+that gets keytab from pod annotation, creates user, gets ticket and preps
+everything for container runtime to be able to do successful mount.
 
 ## Iteration
 
 ```bash
-make status   # Check what's running
-make clean    # Clean K8s only (keeps NFS + KDC)
+make status                                      # Check what's running
+make clean                                       # Clean kubeadm K8s cluster, and tickets etc
 make deploy KDC=<kdc_hostname> NFS=<nfs_hostname>  # Deploy cluster
+
+# Testing options:
+make test                # Full test suite (5 minutes)
+make test-persistent     # Test data persistence across pod restarts
+make test-renewal        # Test Kerberos renewal lifecycle (~2 hours)
 ```
 
 ## Files
@@ -88,24 +90,15 @@ make deploy KDC=<kdc_hostname> NFS=<nfs_hostname>  # Deploy cluster
 
 **Manifests:**
 - `k8s-manifests/client-user*.yaml` - Pod manifests using configmaps
-- `k8s-manifests/pvc-user*.yaml` - PVC manifests
 - `k8s-manifests/storageclass.yaml` - Storage class
-- PVs are generated dynamically with correct NFS hostname
+- PVs and PVCs are generated dynamically with correct NFS hostname
 
-**Key Features:**
-- Uses nip.io hostnames instead of /etc/hosts
-- ConfigMaps for dynamic hostname configuration
-- PVs generated dynamically in deploy script
-- Role-based installation with unified command interface
-- **NRI Integration**: Dynamic user creation via NRI hooks
-- No modification of committed git manifests
+## NRI Mode (Dynamic User Ticket Management)
 
-## NRI Mode (Dynamic User Creation)
-
-The system uses NRI (Node Runtime Interface) hooks to:
-- Dynamically create users when pods are scheduled
-- Download keytabs and perform Kerberos authentication before NFS mount
-- Clean up users and credentials when pods are deleted
+The system uses NRI (Node Resource Interface) plugin to:
+- Download keytabs and perform Kerberos authentication before NFS mount happens
+- Secure keytabs and credentials to the pod user id
+- Clean up users and credentials when pods are deleted (TBD)
 
 ## File Structure
 
@@ -115,6 +108,7 @@ The system uses NRI (Node Runtime Interface) hooks to:
 - `nri-plugin`: custom Kerberos auth'ing NRI plugin
 - `nri-hooks/`: NRI hook scripts for user management
 - `deploy-k8s.sh`: Full cluster deployment
+- `status.sh`: K8s node status check
 - `test.sh`: Validation suite
 
 ## Troubleshooting
@@ -123,14 +117,14 @@ The system uses NRI (Node Runtime Interface) hooks to:
 make status                                         # Overall health
 kubectl logs client-user10002 -c krb5-sidecar       # Sidecar logs
 kubectl logs client-user10002 -c nfs-client         # Client logs
-sudo systemctl status kcm                           # KCM daemon
+sudo systemctl status rpc-gssd                      # GSS daemon
 sudo exportfs -v                                    # NFS exports
 sudo -u user10002 klist -e                          # User tickets
 ```
 
 ## Common Issues
 
-- KCM socket missing: `ls -la /var/run/kcm.socket`
+- FILE credential caches missing: `ls -la /tmp/krb5cc_*`
 - GSS modules not loaded: `lsmod | grep gss`
 - RPC pipefs not mounted: `mount | grep rpc_pipefs`
 - Host keytab missing NFS principals: `klist -k /etc/krb5.keytab`

--- a/cleanup-k8s.sh
+++ b/cleanup-k8s.sh
@@ -15,8 +15,7 @@ print_yellow() { echo -e "${YELLOW}$*${NC}"; }
 
 # users and groups
 USERS=("user10002" "user10003" "user10004" "user10005" "user10006")
-GROUPS=("group5002" "group5003" "group5004" "group5005" "group5006"
-)
+GROUPS=("group5002" "group5003" "group5004" "group5005" "group5006")
 print_yellow "Starting Kubernetes cluster cleanup..."
 
 # Reset Kubernetes cluster
@@ -67,13 +66,13 @@ sudo rm -f /tmp/kubeadm-config.yaml
 # clear local users created for testing
 print_yellow "Removing local test users..."
 for user in "${USERS[@]}"; do
-    sudo deluser --remove-home "${user}" || true
+    sudo useradel -r -f "${user}" || true
 done
 
 # clear local groups created for testing
 print_yellow "Removing local test groups..."
 for group in "${GROUPS[@]}"; do
-    sudo delgroup "${group}" || true
+    sudo groupdel "${group}" || true
 done
 
 # Clean up OCI hooks and related files
@@ -84,8 +83,11 @@ sudo rm -f /opt/nri/plugins/10-kerberos
 
 # Clean up Kerberos credential caches
 print_yellow "Cleaning up Kerberos credential caches..."
-sudo rm -f /tmp/krb5cc_*
-print_yellow "Note: This removes ALL credential caches including system ones - they will be recreated on next deploy"
+
+# Clear FILE-based credential caches
+sudo rm -f /tmp/krb5cc*
+
+print_yellow "Note: This removes ALL FILE-based credential caches including system ones - they will be recreated on next deploy"
 
 # Clean up logs
 print_yellow "Cleaning up Kubernetes logs..."

--- a/containers/krb5-sidecar/Dockerfile
+++ b/containers/krb5-sidecar/Dockerfile
@@ -1,9 +1,8 @@
 FROM ubuntu:24.04
 
-# Install Kerberos packages including KCM
+# Install Kerberos packages for FILE-based credentials
 RUN apt-get update && apt-get install -y \
     krb5-user \
-    heimdal-kcm \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy entrypoint script

--- a/containers/krb5-sidecar/entrypoint.sh
+++ b/containers/krb5-sidecar/entrypoint.sh
@@ -1,35 +1,40 @@
 #!/usr/bin/env bash
 
 # Kerberos sidecar entrypoint script
-# Manages Kerberos credentials using KCM
+# Manages Kerberos credentials using FILE-based credential caches
 
 set -eu
 
 USERNAME=${KERBEROS_USER:-user10002}
 REALM=${KERBEROS_REALM:-EXAMPLE.COM}
 KERBEROS_RENEWAL_TIME=${KERBEROS_RENEWAL_TIME:-86400}
-export KRB5CCNAME=${KRB5CCNAME:-"KCM:"}
+USER_ID=$(id -u)
+export KRB5CCNAME=${KRB5CCNAME:-"FILE:/tmp/krb5cc_${USER_ID}"}
 
 echo "Starting Kerberos sidecar for ${USERNAME}@${REALM}"
 
-# Set KCM as credential cache
+# Use FILE-based credential cache
+echo "Using FILE credential cache: ${KRB5CCNAME}"
 
-# Perform initial authentication
-echo "Getting initial TGT ticket..."
-kinit -k -t /etc/keytabs/${USERNAME}.keytab ${USERNAME}@${REALM}
-
-echo "Initial authentication successful. Tickets:"
+echo "Initial tickets:"
 klist
 
 # Start credential renewal loop
 echo "Starting credential renewal loop (every ${KERBEROS_RENEWAL_TIME} seconds)"
 while true; do
-    sleep ${KERBEROS_RENEWAL_TIME}
+    sleep "${KERBEROS_RENEWAL_TIME}"
     echo "Renewing Kerberos credentials..."
-    kinit -R || {
-        echo "Renewal failed, getting fresh ticket..."
-        kinit -k -t /etc/keytabs/${USERNAME}.keytab ${USERNAME}@${REALM}
-    }
-    echo "Credentials renewed. Current tickets:"
+    if kinit -R; then
+        echo "✓ Credentials renewed successfully"
+    else
+        echo "⚠ Renewal failed, getting fresh ticket..."
+        if kinit -k -t "/etc/keytabs/${USERNAME}.keytab" "${USERNAME}@${REALM}"; then
+            echo "✓ Fresh ticket obtained"
+        else
+            echo "✗ Failed to get fresh ticket"
+            exit 1
+        fi
+    fi
+    echo "Current tickets:"
     klist
 done

--- a/containers/nfs-client/Dockerfile
+++ b/containers/nfs-client/Dockerfile
@@ -18,14 +18,6 @@ RUN apt-get update && \
         iputils-ping \
     && rm -rf /var/lib/apt/lists/*
 
-# Create users with correct UIDs/GIDs to match the Kerberos users
-RUN groupadd -g 5002 group10002 && \
-    groupadd -g 5003 group10003 && \
-    groupadd -g 5004 group10004 && \
-    useradd -u 10002 -g 5002 -m -s /bin/bash user10002 && \
-    useradd -u 10003 -g 5003 -m -s /bin/bash user10003 && \
-    useradd -u 10004 -g 5004 -m -s /bin/bash user10004
-
 # Create a directory for mounting keytabs
 RUN mkdir -p /etc/keytabs && chmod 755 /etc/keytabs
 

--- a/containers/nfs-client/entrypoint.sh
+++ b/containers/nfs-client/entrypoint.sh
@@ -2,27 +2,34 @@
 
 set -eu
 
-USER_ID=${KERBEROS_USER:-user10002}
+# not used by all testing scenarios
+USERNAME=${KERBEROS_USER:-user10002}
+USER_ID=$(id -u)
 REALM=${KERBEROS_REALM:-EXAMPLE.COM}
+export KRB5CCNAME=${KRB5CCNAME:-"FILE:/tmp/krb5cc_${USER_ID}"}
 
-echo "Starting NFS client container with KCM..."
+echo "Starting NFS client container with FILE credentials..."
 echo "Waiting for sidecar to authenticate..."
 
-# Wait for KCM credentials from sidecar
+# Wait for FILE credentials from sidecar
 while ! klist 2>/dev/null; do
-    echo "Waiting for KCM credentials..."
+    echo "Waiting for FILE credentials..."
     sleep 2
 done
 
-echo "Checking KCM credentials..."
+echo "Checking FILE credentials..."
 klist
 
 echo "Testing NFS access..."
 ls -la /home/ || echo "Cannot access NFS directory"
 
 echo "Testing NFS write..."
-echo "test" > /home/test.txt 2>/dev/null && echo "NFS write successful" || echo "Cannot write to NFS"
+date > /home/test.txt 2>/dev/null && echo "NFS write successful" || echo "Cannot write to NFS"
 cat /home/test.txt || echo "Cannot read test file"
 
 echo "Container ready. Keeping alive..."
-tail -f /dev/null
+while true; do
+    echo "Sleeping for ${NFS_WRITE_INTERVAL:-300} seconds before next write..."
+    sleep "${NFS_WRITE_INTERVAL:-300}"
+    date >> /home/test.txt && echo "NFS write successful: $(date)" || echo "failed write to nfs: $(date)"
+done

--- a/deploy-k8s.sh
+++ b/deploy-k8s.sh
@@ -64,10 +64,10 @@ print_yellow "Build NFS Kerberos client Docker image..."
 docker build -t nfs-kerberos-client:latest containers/nfs-client/
 print_green "✓ NFS Kerberos client image built"
 
-# Build KCM sidecar Docker image
-print_yellow "Build KCM sidecar Docker image..."
+# Build Kerberos sidecar Docker image
+print_yellow "Build Kerberos sidecar Docker image..."
 docker build -t krb5-sidecar:latest containers/krb5-sidecar/
-print_green "✓ KCM sidecar image built"
+print_green "✓ Kerberos sidecar image built"
 
 # Import images to containerd for Kubernetes
 docker save nfs-kerberos-client:latest | sudo ctr -n k8s.io images import -
@@ -228,7 +228,6 @@ unset KRB5CCNAME
 
 # Start the system credentials service if keytab is available
 sudo systemctl start kerberos-system-creds 2>/dev/null || true
-
 print_green "✓ System credentials initialized"
 
 # Ensure required daemons are running (they sometimes stop after cluster operations)
@@ -236,7 +235,7 @@ print_yellow "Restarting critical daemons to ensure fresh state..."
 
 # Restart daemons to ensure they're running with fresh configuration
 # (These should already be enabled by install-k8s.sh)
-sudo systemctl restart rpcbind rpc-gssd kcm || true
+sudo systemctl restart rpcbind rpc-gssd || true
 sudo systemctl start rpc-gssd || true
 
 print_green "✓ Critical daemons restarted"
@@ -289,10 +288,8 @@ EOF
 done
 print_green "✓ Persistent volume claims deployed"
 
-# Deploy client pods with KCM sidecar (they now use configmap for hostnames)
+# Deploy client pods with FILE-based credentials (they now use configmap for hostnames)
 for user in "${USERS[@]}"; do
     kubectl apply -f "k8s-manifests/client-${user}.yaml"
 done
-print_green "✓ KCM-based NFS client pods deployed"
-
-print_green "✓ Deployment complete!"
+print_green "✓ FILE-based NFS client pods deployed"

--- a/k8s-manifests/client-user10002.yaml
+++ b/k8s-manifests/client-user10002.yaml
@@ -8,6 +8,7 @@ metadata:
     nri.io/kerberos-uid: "10002"
     nri.io/kerberos-gid: "5002"
     nri.io/kerberos-fsid: "5002"
+    nri.io/kerberos-scenario: "sidecar + client all info / 3 minute refresh"
 spec:
   securityContext:
     runAsUser: 10002
@@ -23,7 +24,7 @@ spec:
       runAsGroup: 5002
     env:
     - name: KRB5CCNAME
-      value: "KCM:"
+      value: "FILE:/tmp/krb5cc_10002"
     - name: KERBEROS_USER
       value: "user10002"
     - name: KERBEROS_REALM
@@ -42,7 +43,7 @@ spec:
           name: service-hostnames
           key: NFS_HOSTNAME
     - name: KERBEROS_RENEWAL_TIME
-      value: "300"  # 5 min for testing
+      value: "180"  # 3 minutes
     volumeMounts:
     - name: keytabs
       mountPath: /etc/keytabs
@@ -50,8 +51,8 @@ spec:
     - name: krb5-config
       mountPath: /etc/krb5.conf
       readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+    - name: ccache
+      mountPath: /tmp
     lifecycle:
       preStop:
         exec:
@@ -65,7 +66,7 @@ spec:
       runAsGroup: 5002
     env:
     - name: KRB5CCNAME
-      value: "KCM:"
+      value: "FILE:/tmp/krb5cc_10002"
     - name: KERBEROS_USER
       value: "user10002"
     - name: KERBEROS_REALM
@@ -83,6 +84,8 @@ spec:
         configMapKeyRef:
           name: service-hostnames
           key: NFS_HOSTNAME
+    - name: NFS_WRITE_INTERVAL
+      value: "60"
     command: ["/usr/local/bin/entrypoint.sh"]
     volumeMounts:
     - name: nfs-home
@@ -93,8 +96,8 @@ spec:
     - name: krb5-config
       mountPath: /etc/krb5.conf
       readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+    - name: ccache
+      mountPath: /tmp
   volumes:
   - name: nfs-home
     persistentVolumeClaim:
@@ -107,8 +110,8 @@ spec:
     hostPath:
       path: /etc/krb5.conf
       type: File
-  - name: kcm-socket
+  - name: ccache
     hostPath:
-      path: /var/run/.heim_org.h5l.kcm-socket
-      type: Socket
+      path: /tmp
+      type: Directory
   restartPolicy: Always

--- a/k8s-manifests/client-user10003.yaml
+++ b/k8s-manifests/client-user10003.yaml
@@ -8,22 +8,23 @@ metadata:
     nri.io/kerberos-uid: "10003"
     nri.io/kerberos-gid: "5003"
     nri.io/kerberos-fsid: "5003"
+    nri.io/kerberos-scenario: "no sidecar"
 spec:
   securityContext:
     runAsUser: 10003
     runAsGroup: 5003
     fsGroup: 5003
   containers:
-  # Kerberos sidecar for credential management
-  - name: krb5-sidecar
-    image: krb5-sidecar:latest
+  # Main NFS client container
+  - name: nfs-client
+    image: nfs-kerberos-client:latest
     imagePullPolicy: Never
     securityContext:
       runAsUser: 10003
       runAsGroup: 5003
     env:
     - name: KRB5CCNAME
-      value: "KCM:"
+      value: "FILE:/tmp/krb5cc_10003"
     - name: KERBEROS_USER
       value: "user10003"
     - name: KERBEROS_REALM
@@ -42,48 +43,9 @@ spec:
           name: service-hostnames
           key: NFS_HOSTNAME
     - name: KERBEROS_RENEWAL_TIME
-      value: "300"  # 5 min for testing
-    volumeMounts:
-    - name: keytabs
-      mountPath: /etc/keytabs
-      readOnly: true
-    - name: krb5-config
-      mountPath: /etc/krb5.conf
-      readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/usr/bin/kdestroy"]
-  # Main NFS client container
-  - name: nfs-client
-    image: nfs-kerberos-client:latest
-    imagePullPolicy: Never
-    securityContext:
-      runAsUser: 10003
-      runAsGroup: 5003
-    env:
-    - name: KRB5CCNAME
-      value: "KCM:"
-    - name: KERBEROS_USER
-      value: "user10003"
-    - name: KERBEROS_REALM
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KERBEROS_REALM
-    - name: KDC_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KDC_HOSTNAME
-    - name: NFS_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: NFS_HOSTNAME
-    command: ["/usr/local/bin/entrypoint.sh"]
+      value: "300"
+    - name: NFS_WRITE_INTERVAL
+      value: "120"
     volumeMounts:
     - name: nfs-home
       mountPath: /home
@@ -93,8 +55,8 @@ spec:
     - name: krb5-config
       mountPath: /etc/krb5.conf
       readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+    - name: ccache
+      mountPath: /tmp
   volumes:
   - name: nfs-home
     persistentVolumeClaim:
@@ -107,8 +69,8 @@ spec:
     hostPath:
       path: /etc/krb5.conf
       type: File
-  - name: kcm-socket
+  - name: ccache
     hostPath:
-      path: /var/run/.heim_org.h5l.kcm-socket
-      type: Socket
+      path: /tmp
+      type: Directory
   restartPolicy: Always

--- a/k8s-manifests/client-user10004.yaml
+++ b/k8s-manifests/client-user10004.yaml
@@ -8,22 +8,23 @@ metadata:
     nri.io/kerberos-uid: "10004"
     nri.io/kerberos-gid: "5004"
     nri.io/kerberos-fsid: "5004"
+    nri.io/kerberos-scenario: "ccache mount + cronjob renewal at 5 mins"
 spec:
   securityContext:
     runAsUser: 10004
     runAsGroup: 5004
     fsGroup: 5004
   containers:
-  # Kerberos sidecar for credential management
-  - name: krb5-sidecar
-    image: krb5-sidecar:latest
+  # Main NFS client container
+  - name: nfs-client
+    image: nfs-kerberos-client:latest
     imagePullPolicy: Never
     securityContext:
       runAsUser: 10004
       runAsGroup: 5004
     env:
     - name: KRB5CCNAME
-      value: "KCM:"
+      value: "FILE:/tmp/krb5cc_10004"
     - name: KERBEROS_USER
       value: "user10004"
     - name: KERBEROS_REALM
@@ -42,47 +43,9 @@ spec:
           name: service-hostnames
           key: NFS_HOSTNAME
     - name: KERBEROS_RENEWAL_TIME
-      value: "300"  # 5 min for testing
-    volumeMounts:
-    - name: keytabs
-      mountPath: /etc/keytabs
-      readOnly: true
-    - name: krb5-config
-      mountPath: /etc/krb5.conf
-      readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/usr/bin/kdestroy"]
-  # Main NFS client container
-  - name: nfs-client
-    image: nfs-kerberos-client:latest
-    imagePullPolicy: Never
-    #securityContext:
-    #  runAsUser: 10004
-    #  runAsGroup: 5004
-    env:
-    - name: KRB5CCNAME
-      value: "KCM:"
-    - name: KERBEROS_USER
-      value: "user10004"
-    - name: KERBEROS_REALM
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KERBEROS_REALM
-    - name: KDC_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KDC_HOSTNAME
-    - name: NFS_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: NFS_HOSTNAME
+      value: "300"
+    - name: NFS_WRITE_INTERVAL
+      value: "180"
     command: ["/usr/local/bin/entrypoint.sh"]
     volumeMounts:
     - name: nfs-home
@@ -93,8 +56,8 @@ spec:
     - name: krb5-config
       mountPath: /etc/krb5.conf
       readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+    - name: ccache
+      mountPath: /tmp
   volumes:
   - name: nfs-home
     persistentVolumeClaim:
@@ -107,8 +70,120 @@ spec:
     hostPath:
       path: /etc/krb5.conf
       type: File
-  - name: kcm-socket
+  - name: ccache
     hostPath:
-      path: /var/run/.heim_org.h5l.kcm-socket
-      type: Socket
+      path: /tmp
+      type: Directory
   restartPolicy: Always
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: kerberos-renewal-user10004
+  namespace: default
+spec:
+  schedule: "*/5 * * * *"  # Every 5 minutes
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          annotations:
+            nri.io/kerberos-auth: "enabled"
+            nri.io/kerberos-uid: "10004"
+            nri.io/kerberos-gid: "5004"
+            nri.io/kerberos-fsid: "5004"
+            nri.io/kerberos-scenario: "cronjob renewal for user10004"
+        spec:
+          securityContext:
+            runAsUser: 10004
+            runAsGroup: 5004
+            fsGroup: 5004
+          restartPolicy: OnFailure
+          containers:
+          - name: kerberos-renewer
+            image: krb5-sidecar:latest
+            imagePullPolicy: Never
+            securityContext:
+              runAsUser: 10004
+              runAsGroup: 5004
+            env:
+            - name: KRB5CCNAME
+              value: "FILE:/tmp/krb5cc_10004"
+            - name: KERBEROS_USER
+              value: "user10004"
+            - name: KERBEROS_REALM
+              valueFrom:
+                configMapKeyRef:
+                  name: service-hostnames
+                  key: KERBEROS_REALM
+            - name: KDC_HOSTNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: service-hostnames
+                  key: KDC_HOSTNAME
+            - name: NFS_HOSTNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: service-hostnames
+                  key: NFS_HOSTNAME
+            command: ["/bin/bash"]
+            args:
+            - -c
+            - |
+              set -eu
+
+              USERNAME=${KERBEROS_USER:-user10004}
+              REALM=${KERBEROS_REALM:-EXAMPLE.COM}
+              USER_ID=$(id -u)
+              export KRB5CCNAME=${KRB5CCNAME:-"FILE:/tmp/krb5cc_${USER_ID}"}
+
+              echo "=== Kerberos Renewal CronJob for ${USERNAME}@${REALM} ==="
+              echo "Timestamp: $(date)"
+              echo "Using FILE credential cache: ${KRB5CCNAME}"
+
+              echo "Current tickets before renewal:"
+              klist || echo "No existing tickets found"
+
+              echo "Attempting credential renewal..."
+              if kinit -R; then
+                  echo "✓ Credentials renewed successfully at $(date)"
+              else
+                  echo "⚠ Renewal failed, getting fresh ticket..."
+                  if kinit -k -t "/etc/keytabs/${USERNAME}.keytab" "${USERNAME}@${REALM}"; then
+                      echo "✓ Fresh ticket obtained at $(date)"
+                  else
+                      echo "✗ Failed to get fresh ticket at $(date)"
+                      exit 1
+                  fi
+              fi
+
+              echo "Current tickets after renewal:"
+              klist
+
+              echo "=== Renewal completed successfully at $(date) ==="
+            volumeMounts:
+            - name: keytabs
+              mountPath: /etc/keytabs
+              readOnly: true
+            - name: krb5-config
+              mountPath: /etc/krb5.conf
+              readOnly: true
+            - name: ccache
+              mountPath: /tmp
+          volumes:
+          - name: keytabs
+            hostPath:
+              path: /etc/keytabs
+              type: Directory
+          - name: krb5-config
+            hostPath:
+              path: /etc/krb5.conf
+              type: File
+          - name: ccache
+            hostPath:
+              path: /tmp
+              type: Directory

--- a/k8s-manifests/client-user10005.yaml
+++ b/k8s-manifests/client-user10005.yaml
@@ -8,6 +8,7 @@ metadata:
     nri.io/kerberos-uid: "10005"
     nri.io/kerberos-gid: "5005"
     nri.io/kerberos-fsid: "5005"
+    nri.io/kerberos-scenario: "nothing about nfs in client, 8 minute refresh"
 spec:
   securityContext:
     runAsUser: 10005
@@ -17,13 +18,13 @@ spec:
   # Kerberos sidecar for credential management
   - name: krb5-sidecar
     image: krb5-sidecar:latest
-    imagePullPolicy: Never
     securityContext:
       runAsUser: 10005
       runAsGroup: 5005
+    imagePullPolicy: Never
     env:
     - name: KRB5CCNAME
-      value: "KCM:"
+      value: "FILE:/tmp/krb5cc_10005"
     - name: KERBEROS_USER
       value: "user10005"
     - name: KERBEROS_REALM
@@ -42,7 +43,7 @@ spec:
           name: service-hostnames
           key: NFS_HOSTNAME
     - name: KERBEROS_RENEWAL_TIME
-      value: "300"  # 5 min for testing
+      value: "480"  # 8 min for testing
     volumeMounts:
     - name: keytabs
       mountPath: /etc/keytabs
@@ -50,8 +51,8 @@ spec:
     - name: krb5-config
       mountPath: /etc/krb5.conf
       readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+    - name: ccache
+      mountPath: /tmp
     lifecycle:
       preStop:
         exec:
@@ -59,42 +60,17 @@ spec:
   # Main NFS client container
   - name: nfs-client
     image: nfs-kerberos-client:latest
-    imagePullPolicy: Never
     securityContext:
       runAsUser: 10005
       runAsGroup: 5005
-    env:
-    - name: KRB5CCNAME
-      value: "KCM:"
-    - name: KERBEROS_USER
-      value: "user10005"
-    - name: KERBEROS_REALM
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KERBEROS_REALM
-    - name: KDC_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KDC_HOSTNAME
-    - name: NFS_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: NFS_HOSTNAME
+    imagePullPolicy: Never
     command: ["/usr/local/bin/entrypoint.sh"]
     volumeMounts:
     - name: nfs-home
       mountPath: /home
-    - name: keytabs
-      mountPath: /etc/keytabs
-      readOnly: true
-    - name: krb5-config
-      mountPath: /etc/krb5.conf
-      readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+    env:
+    - name: NFS_WRITE_INTERVAL
+      value: "240"
   volumes:
   - name: nfs-home
     persistentVolumeClaim:
@@ -107,8 +83,8 @@ spec:
     hostPath:
       path: /etc/krb5.conf
       type: File
-  - name: kcm-socket
+  - name: ccache
     hostPath:
-      path: /var/run/.heim_org.h5l.kcm-socket
-      type: Socket
+      path: /tmp
+      type: Directory
   restartPolicy: Always

--- a/k8s-manifests/client-user10006.yaml
+++ b/k8s-manifests/client-user10006.yaml
@@ -8,22 +8,26 @@ metadata:
     nri.io/kerberos-uid: "10006"
     nri.io/kerberos-gid: "5006"
     nri.io/kerberos-fsid: "5006"
+    nri.io/kerberos-scenario: "no krb5 mounts, only env"
 spec:
   securityContext:
     runAsUser: 10006
     runAsGroup: 5006
     fsGroup: 5006
   containers:
-  # Kerberos sidecar for credential management
-  - name: krb5-sidecar
-    image: krb5-sidecar:latest
+  - name: nfs-client
+    image: nfs-kerberos-client:latest
     imagePullPolicy: Never
     securityContext:
       runAsUser: 10006
       runAsGroup: 5006
+    command: ["/usr/local/bin/entrypoint.sh"]
+    volumeMounts:
+    - name: nfs-home
+      mountPath: /home
     env:
     - name: KRB5CCNAME
-      value: "KCM:"
+      value: "FILE:/tmp/krb5cc_10006"
     - name: KERBEROS_USER
       value: "user10006"
     - name: KERBEROS_REALM
@@ -42,73 +46,11 @@ spec:
           name: service-hostnames
           key: NFS_HOSTNAME
     - name: KERBEROS_RENEWAL_TIME
-      value: "300"  # 5 min for testing
-    volumeMounts:
-    - name: keytabs
-      mountPath: /etc/keytabs
-      readOnly: true
-    - name: krb5-config
-      mountPath: /etc/krb5.conf
-      readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
-    lifecycle:
-      preStop:
-        exec:
-          command: ["/usr/bin/kdestroy"]
-  # Main NFS client container
-  - name: nfs-client
-    image: nfs-kerberos-client:latest
-    imagePullPolicy: Never
-    securityContext:
-      runAsUser: 10006
-      runAsGroup: 5006
-    env:
-    - name: KRB5CCNAME
-      value: "KCM:"
-    - name: KERBEROS_USER
-      value: "user10006"
-    - name: KERBEROS_REALM
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KERBEROS_REALM
-    - name: KDC_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: KDC_HOSTNAME
-    - name: NFS_HOSTNAME
-      valueFrom:
-        configMapKeyRef:
-          name: service-hostnames
-          key: NFS_HOSTNAME
-    command: ["/usr/local/bin/entrypoint.sh"]
-    volumeMounts:
-    - name: nfs-home
-      mountPath: /home
-    - name: keytabs
-      mountPath: /etc/keytabs
-      readOnly: true
-    - name: krb5-config
-      mountPath: /etc/krb5.conf
-      readOnly: true
-    - name: kcm-socket
-      mountPath: /var/run/.heim_org.h5l.kcm-socket
+      value: "300"
+    - name: NFS_WRITE_INTERVAL
+      value: "300"
   volumes:
   - name: nfs-home
     persistentVolumeClaim:
       claimName: nfs-user10006
-  - name: keytabs
-    hostPath:
-      path: /etc/keytabs
-      type: Directory
-  - name: krb5-config
-    hostPath:
-      path: /etc/krb5.conf
-      type: File
-  - name: kcm-socket
-    hostPath:
-      path: /var/run/.heim_org.h5l.kcm-socket
-      type: Socket
   restartPolicy: Always

--- a/k8s-manifests/storageclass.yaml
+++ b/k8s-manifests/storageclass.yaml
@@ -9,3 +9,5 @@ mountOptions:
   - sec=krb5
   - hard
   - nolock
+  - timeo=600
+  - retrans=2

--- a/test.sh
+++ b/test.sh
@@ -16,6 +16,25 @@ USERS=("user10002" "user10003" "user10004" "user10005" "user10006")
 TEST_FILE_PREFIX="test-file"
 TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
 
+# Global variable to track failed users from last test
+LAST_TEST_FAILED_USERS=()
+
+# Configuration - detect from configmap
+if kubectl get configmap service-hostnames &> /dev/null; then
+    KDC_SERVER=$(kubectl get configmap service-hostnames -o jsonpath='{.data.KDC_HOSTNAME}' 2>/dev/null)
+    NFS_SERVER=$(kubectl get configmap service-hostnames -o jsonpath='{.data.NFS_HOSTNAME}' 2>/dev/null)
+
+    if [[ -z "${KDC_SERVER}" || -z "${NFS_SERVER}" ]]; then
+        echo "ERROR: Failed to read hostnames from ConfigMap"
+        echo "Make sure the deployment has been run properly"
+        exit 1
+    fi
+else
+    echo "ERROR: service-hostnames ConfigMap not found"
+    echo "Make sure the deployment has been run and ConfigMap is created"
+    exit 1
+fi
+
 # Helper functions
 print_header() {
     echo -e "\n${BLUE}=== $1 ===${NC}"
@@ -33,11 +52,175 @@ print_warning() {
     echo -e "${YELLOW}⚠ $1${NC}"
 }
 
+# Get KRB5CCNAME value from a pod's environment
+get_krb5ccname() {
+    local user="$1"
+    local container="${2:-nfs-client}"  # Default to nfs-client container
+    local pod_name="client-${user}"
+
+    # Get KRB5CCNAME environment variable from the pod
+    local ccname=$(kubectl exec "${pod_name}" -c "${container}" -- printenv KRB5CCNAME 2>/dev/null || echo "")
+
+    # Default to FILE cache based on user ID if not set
+    if [[ -z "${ccname}" ]]; then
+        local uid=$(echo "${user}" | sed 's/user//')
+        ccname="FILE:/tmp/krb5cc_${uid}"
+    fi
+
+    echo "${ccname}"
+}
+
+# Extract renewal window information from klist output
+extract_renewal_info() {
+    local klist_output="$1"
+    local ticket_type="${2:-krbtgt}"  # Default to TGT, can also be "nfs"
+
+    local expires=""
+    local renew_until=""
+
+    if [[ "${ticket_type}" == "krbtgt" ]]; then
+        expires=$(echo "${klist_output}" | grep "krbtgt/" | head -1 | awk '{print $3, $4}')
+        renew_until=$(echo "${klist_output}" | grep "renew until" | head -1 | awk '{print $4, $5}')
+    elif [[ "${ticket_type}" == "nfs" ]]; then
+        # Look for actual NFS service ticket lines (not Default principal line)
+        # Ticket lines have date/time in first two columns
+        expires=$(echo "${klist_output}" | grep "nfs/" | grep -v "Default principal" | head -1 | awk '{print $3, $4}')
+    fi
+
+    echo "${expires}|${renew_until}"
+}
+
+# Calculate relative time until expiration
+calculate_time_until() {
+    local timestamp="$1"
+
+    # Skip empty or malformed timestamps
+    if [[ -z "${timestamp}" ]] || [[ "${timestamp}" == " " ]]; then
+        echo ""
+        return
+    fi
+
+    # Convert timestamp to epoch time
+    local target_epoch=$(date -d "${timestamp}" +%s 2>/dev/null || echo "0")
+    local current_epoch=$(date +%s)
+
+    if [[ "${target_epoch}" -eq 0 ]]; then
+        echo "unknown"
+        return
+    fi
+
+    local diff=$((target_epoch - current_epoch))
+
+    if [[ ${diff} -lt 0 ]]; then
+        echo "expired"
+        return
+    fi
+
+    local hours=$((diff / 3600))
+    local minutes=$(((diff % 3600) / 60))
+    local seconds=$((diff % 60))
+
+    if [[ ${hours} -gt 0 ]]; then
+        echo "${hours}h ${minutes}m ${seconds}s"
+    elif [[ ${minutes} -gt 0 ]]; then
+        echo "${minutes}m ${seconds}s"
+    else
+        echo "${seconds}s"
+    fi
+}
+
+# Check credentials in container using the appropriate cache type
+check_container_credentials() {
+    local user="$1"
+    local container="${2:-nfs-client}"
+    local pod_name="client-${user}"
+
+    echo "Checking ${user} (${container}) credentials..."
+
+    # Get the credential cache type from the pod
+    local ccname=$(get_krb5ccname "${user}" "${container}")
+
+    # Run klist in the container
+    local klist_output=$(kubectl exec "${pod_name}" -c "${container}" -- klist 2>/dev/null || echo "NO_CREDENTIALS")
+
+    if echo "${klist_output}" | grep -q "${user}@EXAMPLE.COM"; then
+        # Extract renewal information
+        local renewal_info=$(extract_renewal_info "${klist_output}" "krbtgt")
+        local expires=$(echo "${renewal_info}" | cut -d'|' -f1)
+        local renew_until=$(echo "${renewal_info}" | cut -d'|' -f2)
+
+        print_success "${user} (${container}): Valid credentials [${ccname}]"
+        echo "  └─ Expires: ${expires}"
+        if [[ -n "${renew_until}" ]]; then
+            echo "  └─ Renew until: ${renew_until}"
+        fi
+
+        # Check for NFS service tickets
+        if echo "${klist_output}" | grep -q "nfs/"; then
+            local nfs_renewal_info=$(extract_renewal_info "${klist_output}" "nfs")
+            local nfs_expires=$(echo "${nfs_renewal_info}" | cut -d'|' -f1)
+            echo "  └─ NFS service ticket expires: ${nfs_expires}"
+        fi
+
+        return 0
+    else
+        print_error "${user} (${container}): No valid credentials [${ccname}]"
+        echo "Credential cache contents:"
+        echo "${klist_output}" | sed 's/^/  /'
+        return 1
+    fi
+}
+
+test_non_root_user() {
+    print_header "Testing Non-Root User Execution"
+
+    local failed_users=0
+    local failed_user_list=()
+
+    for user in "${USERS[@]}"; do
+        local pod_name="client-${user}"
+        echo "Testing that ${user} is running as non-root..."
+
+        # Check effective user ID - should not be 0 (root)
+        local uid=$(kubectl exec "${pod_name}" -c nfs-client -- id -u 2>/dev/null || echo "FAILED")
+        if [[ "${uid}" == "FAILED" ]]; then
+            print_error "${user}: Failed to get user ID"
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
+        elif [[ "${uid}" == "0" ]]; then
+            print_error "${user}: Running as root (UID 0) - security violation!"
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
+        else
+            print_success "${user}: Running as non-root user (UID ${uid})"
+
+            # Additional check: verify the user ID matches expected range (10002-10006)
+            local expected_uid=${user#user}  # Remove "user" prefix to get numeric ID
+            if [[ "${uid}" == "${expected_uid}" ]]; then
+                print_success "${user}: UID matches expected value (${expected_uid})"
+            else
+                print_warning "${user}: UID (${uid}) doesn't match expected (${expected_uid})"
+            fi
+        fi
+    done
+
+    # Export failed users for tracking
+    LAST_TEST_FAILED_USERS=("${failed_user_list[@]}")
+
+    if [[ ${failed_users} -gt 0 ]]; then
+        print_error "Non-root user test FAILED (${failed_users}/${#USERS[@]} users failed)"
+        return ${failed_users}
+    else
+        print_success "Non-root user test PASSED"
+        return 0
+    fi
+}
+
 wait_for_pods() {
     print_header "Waiting for pods to be ready"
     for user in "${USERS[@]}"; do
         echo "Waiting for client-${user} to be ready..."
-        kubectl wait --for=condition=ready pod/client-${user} --timeout=60s
+        kubectl wait --for=condition=ready "pod/client-${user}" --timeout=60s
     done
     print_success "All pods are ready"
 }
@@ -48,215 +231,583 @@ test_pod_status() {
     echo "Checking pod status:"
     kubectl get pods | grep client-user
 
-    local all_ready=true
+    local failed_users=0
+    local failed_user_list=()
     for user in "${USERS[@]}"; do
         local pod_name="client-${user}"
-        local ready=$(kubectl get pod $pod_name -o jsonpath='{.status.containerStatuses[*].ready}' | grep -o true | wc -l)
-        local total=$(kubectl get pod $pod_name -o jsonpath='{.status.containerStatuses[*]}' | jq length 2>/dev/null || echo "2")
+        local ready=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.containerStatuses[*].ready}' | grep -o true | wc -l)
+        local total=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.containerStatuses[*]}' | jq length 2>/dev/null || echo "unknown")
 
-        if [ "$ready" = "2" ]; then
-            print_success "Pod $pod_name: $ready/$total containers ready"
+        # Expected container counts based on scenarios
+        local expected_containers
+        case "${user}" in
+            user10002|user10005)
+                expected_containers=2  # Has sidecar + nfs-client
+                ;;
+            user10003|user10004|user10006)
+                expected_containers=1  # Only nfs-client (user10004 uses CronJob for renewal)
+                ;;
+            *)
+                expected_containers=2  # Default assumption
+                ;;
+        esac
+
+        if [[ "${ready}" == "${expected_containers}" ]]; then
+            print_success "Pod ${pod_name}: ${ready}/${total} containers ready (expected ${expected_containers})"
         else
-            print_error "Pod $pod_name: $ready/$total containers ready"
-            all_ready=false
+            print_error "Pod ${pod_name}: ${ready}/${total} containers ready (expected ${expected_containers})"
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
         fi
     done
 
-    if [ "$all_ready" = true ]; then
-        print_success "Pod status test PASSED"
+    # Check CronJob status for user10004
+    echo "Checking CronJob status for user10004..."
+    if kubectl get cronjob kerberos-renewal-user10004 &>/dev/null; then
+        local cronjob_status=$(kubectl get cronjob kerberos-renewal-user10004 -o jsonpath='{.spec.suspend}' 2>/dev/null)
+        if [[ "${cronjob_status}" == "true" ]]; then
+            print_warning "CronJob kerberos-renewal-user10004: Suspended"
+        else
+            print_success "CronJob kerberos-renewal-user10004: Active"
+
+            # Check recent job executions
+            local recent_jobs=$(kubectl get jobs --selector='job-name=kerberos-renewal-user10004' --sort-by=.metadata.creationTimestamp 2>/dev/null | tail -3 | wc -l)
+            if [[ ${recent_jobs} -gt 0 ]]; then
+                print_success "CronJob kerberos-renewal-user10004: Has recent job executions"
+            else
+                print_warning "CronJob kerberos-renewal-user10004: No recent job executions found"
+            fi
+        fi
     else
-        print_error "Pod status test FAILED"
-        return 1
+        print_error "CronJob kerberos-renewal-user10004: Not found"
+        failed_users=$((failed_users + 1))
+        failed_user_list+=("user10004")
+    fi
+
+    # Export failed users for tracking
+    LAST_TEST_FAILED_USERS=("${failed_user_list[@]}")
+
+    if [[ ${failed_users} -gt 0 ]]; then
+        print_error "Pod status test FAILED (${failed_users}/${#USERS[@]} users failed)"
+        return ${failed_users}
+    else
+        print_success "Pod status test PASSED"
+        return 0
     fi
 }
 
 test_kerberos_authentication() {
     print_header "Testing Kerberos Authentication"
 
-    for user in "${USERS[@]}"; do
-        local pod_name="client-${user}"
-        echo "Testing Kerberos authentication for $user..."
+    local failed_users=0
+    local failed_user_list=()
 
-        # Check if sidecar can get tickets
-        local klist_output=$(kubectl exec $pod_name -c krb5-sidecar -- klist 2>/dev/null || echo "FAILED")
-        if echo "$klist_output" | grep -q "${user}@EXAMPLE.COM"; then
-            print_success "$user: Kerberos authentication working"
+    for user in "${USERS[@]}"; do
+        echo "Testing Kerberos authentication for ${user}..."
+
+        # Check main nfs-client container first
+        if check_container_credentials "${user}" "nfs-client"; then
+            # Check sidecar container if it exists
+            case "${user}" in
+                user10002|user10005)
+                    # These users have sidecar containers
+                    if check_container_credentials "${user}" "krb5-sidecar"; then
+                        print_success "${user}: Both containers have valid credentials"
+                    else
+                        print_warning "${user}: Main container OK, but sidecar has credential issues"
+                    fi
+                    ;;
+                user10004)
+                    # This user uses CronJob for renewal
+                    print_success "${user}: Container credentials verified (CronJob renewal)"
+                    ;;
+                *)
+                    # These users don't have renewal mechanism
+                    print_success "${user}: Container credentials verified (no renewal)"
+                    ;;
+            esac
         else
-            print_error "$user: Kerberos authentication failed"
-            echo "klist output: $klist_output"
-            return 1
+            print_error "${user}: Main container credential check failed"
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
+
+            # Still check sidecar if it exists for debugging
+            case "${user}" in
+                user10002|user10005)
+                    echo "  Checking sidecar for debugging..."
+                    check_container_credentials "${user}" "krb5-sidecar" || true
+                    ;;
+            esac
         fi
     done
 
-    print_success "Kerberos authentication test PASSED"
+    # Export failed users for tracking
+    LAST_TEST_FAILED_USERS=("${failed_user_list[@]}")
+
+    if [[ ${failed_users} -gt 0 ]]; then
+        print_error "Kerberos authentication test FAILED (${failed_users}/${#USERS[@]} users failed)"
+        return ${failed_users}
+    else
+        print_success "Kerberos authentication test PASSED"
+        return 0
+    fi
 }
 
 test_nfs_mount_access() {
     print_header "Testing NFS Mount Access"
 
+    local failed_users=0
+    local failed_user_list=()
+
     for user in "${USERS[@]}"; do
         local pod_name="client-${user}"
-        echo "Testing NFS mount access for $user..."
+        echo "Testing NFS mount access for ${user}..."
 
         # Test if user can list their home directory
-        local ls_output=$(kubectl exec $pod_name -c nfs-client -- ls -la /home/ 2>&1 || echo "FAILED")
-        if echo "$ls_output" | grep -q "total\|drwx"; then
-            print_success "$user: Can access NFS mount"
-        elif echo "$ls_output" | grep -q "Permission denied\|Stale file handle"; then
-            print_error "$user: NFS mount access denied - Kerberos authentication or mapping issue"
-            return 1
+        local ls_output=$(kubectl exec "${pod_name}" -c nfs-client -- ls -la /home/ 2>&1 || echo "FAILED")
+        if echo "${ls_output}" | grep -q "total\|drwx"; then
+            print_success "${user}: Can access NFS mount"
+        elif echo "${ls_output}" | grep -q "Permission denied\|Stale file handle"; then
+            print_error "${user}: NFS mount access denied - Kerberos authentication or mapping issue"
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
         else
-            print_error "$user: Cannot access NFS mount"
-            echo "ls output: $ls_output"
-            return 1
+            print_error "${user}: Cannot access NFS mount"
+            echo "ls output: ${ls_output}"
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
         fi
     done
 
-    print_success "NFS mount access test PASSED"
+    # Export failed users for tracking
+    LAST_TEST_FAILED_USERS=("${failed_user_list[@]}")
+
+    if [[ ${failed_users} -gt 0 ]]; then
+        print_error "NFS mount access test FAILED (${failed_users}/${#USERS[@]} users failed)"
+        return ${failed_users}
+    else
+        print_success "NFS mount access test PASSED"
+        return 0
+    fi
 }
 
 test_file_operations() {
     print_header "Testing File Operations"
 
+    local failed_users=0
+    local failed_user_list=()
+
     for user in "${USERS[@]}"; do
         local pod_name="client-${user}"
         local test_file="/home/${TEST_FILE_PREFIX}-${user}-${TIMESTAMP}.txt"
-        local test_content="Test file created by $user at $(date)"
+        local test_content="Test file created by ${user} at $(date)"
 
-        echo "Testing file operations for $user..."
+        echo "Testing file operations for ${user}..."
+        local user_failed=false
 
         # Test file creation
-        kubectl exec $pod_name -c nfs-client -- sh -c "echo '$test_content' > $test_file" 2>/dev/null
-        if [ $? -eq 0 ]; then
-            print_success "$user: Can create files"
+        kubectl exec "${pod_name}" -c nfs-client -- sh -c "echo '${test_content}' > ${test_file}" 2>/dev/null
+        if [[ $? -eq 0 ]]; then
+            print_success "${user}: Can create files"
         else
-            print_error "$user: Cannot create files"
-            return 1
+            print_error "${user}: Cannot create files"
+            user_failed=true
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
+            continue  # Skip other tests for this user if creation fails
         fi
 
         # Test file reading
-        local read_content=$(kubectl exec $pod_name -c nfs-client -- cat $test_file 2>/dev/null)
-        if [ "$read_content" = "$test_content" ]; then
-            print_success "$user: Can read own files"
+        local read_content=$(kubectl exec "${pod_name}" -c nfs-client -- cat "${test_file}" 2>/dev/null)
+        if [[ "${read_content}" == "${test_content}" ]]; then
+            print_success "${user}: Can read own files"
         else
-            print_error "$user: Cannot read own files"
-            return 1
+            print_error "${user}: Cannot read own files"
+            user_failed=true
         fi
 
         # Test file modification
-        local new_content="Modified by $user at $(date)"
-        kubectl exec $pod_name -c nfs-client -- sh -c "echo '$new_content' >> $test_file" 2>/dev/null
-        if [ $? -eq 0 ]; then
-            print_success "$user: Can modify own files"
+        local new_content="Modified by ${user} at $(date)"
+        kubectl exec "${pod_name}" -c nfs-client -- sh -c "echo '${new_content}' >> ${test_file}" 2>/dev/null
+        if [[ $? -eq 0 ]]; then
+            print_success "${user}: Can modify own files"
         else
-            print_error "$user: Cannot modify own files"
-            return 1
+            print_error "${user}: Cannot modify own files"
+            user_failed=true
+        fi
+
+        # Count this user as failed if any of the operations failed (but not already counted)
+        if [[ "${user_failed}" == "true" ]] && [[ ${failed_users} -eq 0 || "${failed_user_list[-1]}" != "${user}" ]]; then
+            failed_users=$((failed_users + 1))
+            failed_user_list+=("${user}")
         fi
     done
 
-    print_success "File operations test PASSED"
+    # Export failed users for tracking
+    LAST_TEST_FAILED_USERS=("${failed_user_list[@]}")
+
+    if [[ ${failed_users} -gt 0 ]]; then
+        print_error "File operations test FAILED (${failed_users}/${#USERS[@]} users failed)"
+        return ${failed_users}
+    else
+        print_success "File operations test PASSED"
+        return 0
+    fi
 }
 
 test_persistent_storage() {
     print_header "Testing Persistent Storage"
 
+    local failed_users=0
+
     for user in "${USERS[@]}"; do
         local pod_name="client-${user}"
         local persistent_file="/home/persistent-test-${user}.txt"
-        local content="Persistent data for $user created at $(date)"
+        local content="Persistent data for ${user} created at $(date)"
 
-        echo "Testing persistent storage for $user..."
+        echo "Testing persistent storage for ${user}..."
 
         # Create a file
-        kubectl exec $pod_name -c nfs-client -- sh -c "echo '$content' > $persistent_file" 2>/dev/null
+        kubectl exec "${pod_name}" -c nfs-client -- sh -c "echo '${content}' > ${persistent_file}" 2>/dev/null
 
         # Restart the pod
-        echo "Restarting pod $pod_name..."
-        kubectl delete pod $pod_name
-        kubectl apply -f k8s-manifests/client-${user}.yaml
+        echo "Restarting pod ${pod_name}..."
+        kubectl delete pod "${pod_name}"
+        kubectl apply -f "k8s-manifests/client-${user}.yaml"
 
         # Wait for pod to be ready
-        kubectl wait --for=condition=ready pod/$pod_name --timeout=60s
+        kubectl wait --for=condition=ready "pod/${pod_name}" --timeout=60s
 
         # Check if file still exists
-        local read_content=$(kubectl exec $pod_name -c nfs-client -- cat $persistent_file 2>/dev/null || echo "FILE_NOT_FOUND")
-        if [ "$read_content" = "$content" ]; then
-            print_success "$user: Persistent storage working"
+        local read_content=$(kubectl exec "${pod_name}" -c nfs-client -- cat "${persistent_file}" 2>/dev/null || echo "FILE_NOT_FOUND")
+        if [[ "${read_content}" == "${content}" ]]; then
+            print_success "${user}: Persistent storage working"
         else
-            print_error "$user: Persistent storage failed"
-            echo "Expected: $content"
-            echo "Got: $read_content"
-            return 1
+            print_error "${user}: Persistent storage failed"
+            echo "Expected: ${content}"
+            echo "Got: ${read_content}"
+            failed_users=$((failed_users + 1))
         fi
     done
 
-    print_success "Persistent storage test PASSED"
+    if [[ ${failed_users} -gt 0 ]]; then
+        print_error "Persistent storage test FAILED (${failed_users}/${#USERS[@]} users failed)"
+        return ${failed_users}
+    else
+        print_success "Persistent storage test PASSED"
+        return 0
+    fi
 }
 
-test_service_health() {
-    print_header "Testing Service Health"
+check_user_credentials() {
+    local user="$1"
+    local pod_name="client-${user}"
+    local container="nfs-client"
 
-    # Test KDC
-    echo "Testing KDC service..."
-    if sudo systemctl is-active --quiet krb5-kdc; then
-        print_success "KDC service is running"
+    # For users with sidecar, check sidecar container
+    case "${user}" in
+        user10002|user10005)
+            container="krb5-sidecar"
+            ;;
+    esac
+
+    echo "Checking credentials for ${user} in container ${container}..."
+    local klist_output=$(kubectl exec "${pod_name}" -c "${container}" -- klist 2>/dev/null || echo "NO_CREDENTIALS")
+
+    if echo "${klist_output}" | grep -q "${user}@EXAMPLE.COM"; then
+        # Extract renewal information
+        local renewal_info=$(extract_renewal_info "${klist_output}" "krbtgt")
+        local expires=$(echo "${renewal_info}" | cut -d'|' -f1)
+        local renew_until=$(echo "${renewal_info}" | cut -d'|' -f2)
+
+        # Calculate relative time until expiration
+        local time_until_expires=$(calculate_time_until "${expires}")
+
+        # Format the success message
+        if [[ -n "${time_until_expires}" ]]; then
+            print_success "${user}: Has valid credentials (expires: ${expires} in ${time_until_expires})"
+        else
+            print_success "${user}: Has valid credentials (expires: ${expires})"
+        fi
+
+        # Show renewable information if available
+        if [[ -n "${renew_until}" ]] && [[ "${renew_until}" != " " ]]; then
+            local time_until_renew_expires=$(calculate_time_until "${renew_until}")
+            if [[ -n "${time_until_renew_expires}" ]]; then
+                echo "  └─ Renewable until: ${renew_until} (in ${time_until_renew_expires})"
+            else
+                echo "  └─ Renewable until: ${renew_until}"
+            fi
+        fi
+
+        return 0
     else
-        print_error "KDC service is not running"
+        print_error "${user}: No valid credentials"
         return 1
     fi
-
-    # Test NFS server
-    echo "Testing NFS server..."
-    if sudo systemctl is-active --quiet nfs-kernel-server; then
-        print_success "NFS server is running"
-    else
-        print_error "NFS server is not running"
-        return 1
-    fi
-
-    # Test GSS daemon
-    echo "Testing GSS daemon..."
-    if sudo systemctl is-active --quiet rpc-gssd; then
-        print_success "GSS daemon is running"
-    else
-        print_error "GSS daemon is not running"
-        return 1
-    fi
-
-    # Test NFS exports
-    echo "Testing NFS exports..."
-    local exports=$(showmount -e localhost 2>/dev/null | wc -l)
-    if [ "$exports" -gt 1 ]; then
-        print_success "NFS exports are available ($((exports-1)) exports)"
-    else
-        print_error "No NFS exports found"
-        return 1
-    fi
-
-    print_success "Service health test PASSED"
 }
 
-test_nri_integration() {
-    print_header "Testing NRI Integration"
+check_system_credentials() {
+    echo "Checking system NFS credentials..."
 
-    # Check if NRI is enabled
-    echo "Checking NRI configuration..."
-    if sudo grep -q "disable = false" /etc/containerd/config.toml && \
-       sudo grep -A5 -B5 "nri" /etc/containerd/config.toml | grep -q "disable = false"; then
-        print_success "NRI is enabled in containerd"
+    local file_found=false
+    local any_valid=false
+
+    # Check FILE-based cache (system credentials location)
+    echo "  Checking FILE:/tmp/krb5cc_0..."
+    local file_klist_output=$(sudo klist -c FILE:/tmp/krb5cc_0 2>/dev/null || echo "NO_FILE_CREDENTIALS")
+
+    if echo "${file_klist_output}" | grep -q "nfs/.*@EXAMPLE.COM\|krbtgt/.*@EXAMPLE.COM"; then
+        file_found=true
+        local renewal_info=$(extract_renewal_info "${file_klist_output}" "krbtgt")
+        local expires=$(echo "${renewal_info}" | cut -d'|' -f1)
+        local renew_until=$(echo "${renewal_info}" | cut -d'|' -f2)
+
+        # Check if credentials are actually expired
+        local current_epoch=$(date +%s)
+        local expires_epoch=$(date -d "${expires}" +%s 2>/dev/null || echo "0")
+
+        if [[ "${expires_epoch}" -gt "${current_epoch}" ]]; then
+            any_valid=true
+            local time_until=$(calculate_time_until "${expires}")
+            print_success "System FILE cache: Valid credentials"
+            echo "    └─ Expires: ${expires} (in ${time_until})"
+            if [[ -n "${renew_until}" ]] && [[ "${renew_until}" != " " ]]; then
+                local renew_time_until=$(calculate_time_until "${renew_until}")
+                echo "    └─ Renew until: ${renew_until} (in ${renew_time_until})"
+            fi
+        else
+            print_error "System FILE cache: EXPIRED credentials"
+            echo "    └─ Expired: ${expires} ($(calculate_time_until "${expires}"))"
+            if [[ -n "${renew_until}" ]] && [[ "${renew_until}" != " " ]]; then
+                echo "    └─ Renew until: ${renew_until}"
+            fi
+            print_warning "⚠ CRITICAL: System credentials expired - NFS access will fail!"
+        fi
+
+        # Check for NFS service tickets
+        if echo "${file_klist_output}" | grep -q "nfs/"; then
+            local nfs_renewal_info=$(extract_renewal_info "${file_klist_output}" "nfs")
+            local nfs_expires=$(echo "${nfs_renewal_info}" | cut -d'|' -f1)
+            if [[ -n "${nfs_expires}" ]]; then
+                local nfs_expires_epoch=$(date -d "${nfs_expires}" +%s 2>/dev/null || echo "0")
+                if [[ "${nfs_expires_epoch}" -gt "${current_epoch}" ]]; then
+                    local nfs_time_until=$(calculate_time_until "${nfs_expires}")
+                    echo "    └─ NFS service ticket expires: ${nfs_expires} (in ${nfs_time_until})"
+                else
+                    echo "    └─ NFS service ticket EXPIRED: ${nfs_expires} ($(calculate_time_until "${nfs_expires}"))"
+                fi
+            fi
+        fi
     else
-        print_error "NRI is not properly enabled in containerd"
+        print_warning "System FILE cache: No valid credentials"
+    fi
+
+    # Summary
+    if [[ "${any_valid}" == true ]]; then
+        print_success "System credentials: Valid and current"
+        return 0
+    else
+        if [[ "${file_found}" == true ]]; then
+            print_error "System credentials: EXPIRED - NFS will not work!"
+            echo "  ⚠ Fix: Renew system credentials with: sudo kinit -k -t /etc/krb5.keytab nfs/\${NFS_HOSTNAME}@EXAMPLE.COM"
+        else
+            print_error "System credentials: No valid credentials found in FILE cache"
+            echo "  FILE cache contents:"
+            sudo klist -c FILE:/tmp/krb5cc_0 2>&1 | sed 's/^/    /' || echo "    Failed to read FILE cache"
+        fi
+        return 1
+    fi
+}
+
+test_nfs_access_simple() {
+    local user="$1"
+    local pod_name="client-${user}"
+
+    echo "Testing NFS read access for ${user}..."
+    local ls_output=$(kubectl exec "${pod_name}" -c nfs-client -- ls -la /home/ 2>&1 || echo "FAILED")
+    if echo "${ls_output}" | grep -q "total\|drwx"; then
+        print_success "${user}: NFS read access working"
+        return 0
+    else
+        print_error "${user}: NFS read access failed - ${ls_output}"
         return 1
     fi
 
-    # Check if hook scripts are deployed
-    echo "Checking hook script deployment..."
-    if [[ -f /opt/nri-hooks/kerberos.sh ]]; then
-        print_success "Hook scripts are deployed to filesystem"
+    echo "Testing NFS write access for ${user}..."
+    local write_output=$(kubectl exec "${pod_name}" -c nfs-client -- sh -c 'echo "test" > /home/write-test.txt && cat /home/write-test.txt' 2>&1 || echo "FAILED")
+    if echo "${write_output}" | grep -q "test"; then
+        print_success "${user}: NFS write access working"
+        return 0
     else
-        print_error "Hook scripts are not deployed to filesystem"
+        print_error "${user}: NFS write access failed - ${write_output}"
         return 1
     fi
+}
+
+test_kerberos_renewal_lifecycle() {
+    print_header "Testing Kerberos Renewal Lifecycle"
+    echo "This test follows the complete ticket lifecycle with new short lifetimes:"
+    echo "- Initial tickets: 10 minutes"
+    echo "- Max ticket life: 20 minutes"
+    echo "- Renewable for: 30 minutes from initial issue"
+    echo "- Absolute max: 40 minutes total"
+    echo ""
+    echo "System credentials:"
+    echo "- NFS system tickets: renewed every 20 minutes by timer"
+    echo "- Root credential cache: FILE:/tmp/krb5cc_0"
+    echo ""
+    echo "Container credentials:"
+    echo "- All containers use FILE-based caches: FILE:/tmp/krb5cc_[uid]"
+    echo "- Sidecars renew every 5 minutes for users with sidecars (user10002, user10005)"
+    echo "- CronJob renews every 5 minutes for user10004"
+    echo ""
+    echo "Test phases:"
+    echo "1. Fresh start with 'make replace'"
+    echo "2. Wait 6 minutes - check renewal (sidecars renew every 5 min)"
+    echo "3. Wait 12 minutes - check if initial tickets expired"
+    echo "4. Wait 22 minutes - check if max ticket life applies"
+    echo "5. Wait 32 minutes - check if renewable limit applies"
+    echo "6. Wait 42 minutes - check absolute expiration"
+    echo ""
+    print_warning "This test takes approximately 45 minutes to complete"
+    echo ""
+
+    print_header "Phase 0: Fresh Start with make replace"
+    echo "Running 'make replace' to get fresh pods and credentials..."
+    if ! make replace; then
+        print_error "Failed to run 'make replace'"
+        return 1
+    fi
+
+    # Wait for pods to be ready
+    echo "Waiting for pods to be ready after replacement..."
+    sleep 30
+    for user in "${USERS[@]}"; do
+        kubectl wait --for=condition=ready "pod/client-${user}" --timeout=60s
+    done
+
+    local start_time=$(date +%s)
+    echo "Test started at: $(date)"
+    echo "Baseline check - all users should have fresh credentials..."
+
+    # Check system credentials first
+    check_system_credentials || true
+
+    for user in "${USERS[@]}"; do
+        check_user_credentials "${user}" || true
+        test_nfs_access_simple "${user}" || true
+    done
+
+    print_header "Phase 1: Wait 6 minutes - Check Renewal (sidecars and CronJob should renew)"
+    echo "Waiting 6 minutes to verify renewal mechanisms work..."
+    echo "Users with sidecars (user10002, user10005) should show renewed tickets"
+    echo "User with CronJob (user10004) should show renewed tickets"
+    echo "Users without renewal (user10003, user10006) should still have original tickets"
+
+    sleep 360  # 6 minutes
+
+    local current_time=$(date +%s)
+    local elapsed=$(( (current_time - start_time) / 60 ))
+    echo "=== ${elapsed} minutes elapsed ==="
+
+    check_system_credentials || true
+    for user in "${USERS[@]}"; do
+        check_user_credentials "${user}" || true
+        test_nfs_access_simple "${user}" || true
+    done
+
+    print_header "Phase 2: Wait 12 minutes total - Check Initial Ticket Expiration"
+    echo "Waiting 6 more minutes (12 minutes total)..."
+    echo "Initial 10-minute tickets should have expired"
+    echo "Users with sidecars (user10002, user10005) should still work (renewed tickets)"
+    echo "User with CronJob (user10004) should still work (renewed tickets)"
+    echo "Users without renewal (user10003, user10006) may start failing"
+
+    sleep 360  # 6 more minutes (12 total)
+
+    current_time=$(date +%s)
+    elapsed=$(( (current_time - start_time) / 60 ))
+    echo "=== ${elapsed} minutes elapsed ==="
+
+    check_system_credentials || true
+    for user in "${USERS[@]}"; do
+        check_user_credentials "${user}" || true
+        test_nfs_access_simple "${user}" || true
+    done
+
+    print_header "Phase 3: Wait 22 minutes total - Check Max Ticket Life"
+    echo "Waiting 10 more minutes (22 minutes total)..."
+    echo "Max ticket life (20 minutes) should be reached"
+    echo "Even renewed tickets should be limited to 20-minute max life"
+
+    sleep 600  # 10 more minutes (22 total)
+
+    current_time=$(date +%s)
+    elapsed=$(( (current_time - start_time) / 60 ))
+    echo "=== ${elapsed} minutes elapsed ==="
+
+    check_system_credentials || true
+    for user in "${USERS[@]}"; do
+        check_user_credentials "${user}" || true
+        test_nfs_access_simple "${user}" || true
+    done
+
+    print_header "Phase 4: Wait 32 minutes total - Check Renewable Limit"
+    echo "Waiting 10 more minutes (32 minutes total)..."
+    echo "30-minute renewable limit should be reached"
+    echo "Users with sidecars (user10002, user10005) should get fresh tickets (re-authenticate with keytab)"
+    echo "User with CronJob (user10004) should get fresh tickets (re-authenticate with keytab)"
+    echo "Users without renewal (user10003, user10006) should definitely fail"
+
+    sleep 600  # 10 more minutes (32 total)
+
+    current_time=$(date +%s)
+    elapsed=$(( (current_time - start_time) / 60 ))
+    echo "=== ${elapsed} minutes elapsed ==="
+
+    check_system_credentials || true
+    for user in "${USERS[@]}"; do
+        check_user_credentials "${user}" || true
+        test_nfs_access_simple "${user}" || true
+    done
+
+    print_header "Phase 5: Wait 42 minutes total - Check Absolute Expiration"
+    echo "Waiting 10 more minutes (42 minutes total)..."
+    echo "40-minute absolute maximum should be reached"
+    echo "All tickets should require fresh authentication"
+    echo "Only users with renewal mechanisms (sidecars + CronJob) should recover"
+
+    sleep 600  # 10 more minutes (42 total)
+
+    current_time=$(date +%s)
+    elapsed=$(( (current_time - start_time) / 60 ))
+    echo "=== ${elapsed} minutes elapsed ==="
+
+    print_header "Final Check - After 40+ Minute Absolute Expiration"
+    check_system_credentials || true
+    for user in "${USERS[@]}"; do
+        check_user_credentials "${user}" || true
+        test_nfs_access_simple "${user}" || true
+    done
+
+    print_header "Renewal Lifecycle Test Complete"
+    local total_time=$(( (current_time - start_time) / 60 ))
+    echo "Total test duration: ${total_time} minutes"
+    echo ""
+    echo "Expected results:"
+    echo "✓ user10002, user10005: Should work throughout (have sidecars with FILE caches)"
+    echo "✓ user10004: Should work throughout (has CronJob renewal with FILE cache)"
+    echo "✗ user10003, user10006: Should fail after initial expiration (no renewal)"
+    echo ""
+    echo "This test demonstrates:"
+    echo "- Automatic renewal by sidecars using FILE caches"
+    echo "- Automatic renewal by CronJob using FILE caches"
+    echo "- Ticket lifetime limits"
+    echo "- Re-authentication requirements"
+    echo "- System behavior under credential expiration"
+
+    return 0
 }
 
 cleanup_test_files() {
@@ -264,8 +815,8 @@ cleanup_test_files() {
 
     for user in "${USERS[@]}"; do
         local pod_name="client-${user}"
-        echo "Cleaning up test files for $user..."
-        kubectl exec $pod_name -c nfs-client -- sh -c "rm -f /home/${TEST_FILE_PREFIX}-${user}-*.txt" 2>/dev/null || true
+        echo "Cleaning up test files for ${user}..."
+        kubectl exec "${pod_name}" -c nfs-client -- sh -c "rm -f /home/${TEST_FILE_PREFIX}-${user}-*.txt" 2>/dev/null || true
     done
 
     print_success "Test cleanup completed"
@@ -274,59 +825,97 @@ cleanup_test_files() {
 run_all_tests() {
     print_header "Starting NFS Kerberos POC Test Suite"
     echo "Timestamp: $(date)"
-    echo "Test ID: $TIMESTAMP"
+    echo "Test ID: ${TIMESTAMP}"
 
     local tests_passed=0
     local tests_failed=0
     local critical_failure=false
 
+    # Track results per user - associative array where key is user and value is failed test count
+    declare -A user_failures
+    for user in "${USERS[@]}"; do
+        user_failures["${user}"]=0
+    done
+
     # List of core test functions (must pass for system to be functional)
     local core_test_functions=(
-        "test_service_health"
-        "test_nri_integration"
         "test_pod_status"
+        "test_non_root_user"
         "test_kerberos_authentication"
         "test_nfs_mount_access"
         "test_file_operations"
     )
 
+    # Check system credentials first (critical for NFS functionality)
+    echo ""
+    print_header "System Credentials Check"
+    local system_creds_result=0
+    check_system_credentials || system_creds_result=$?
+
+    if [[ ${system_creds_result} -ne 0 ]]; then
+        print_error "CRITICAL: System credentials check failed - NFS operations will not work"
+        critical_failure=true
+        tests_failed=$((tests_failed + 1))
+    else
+        tests_passed=$((tests_passed + 1))
+    fi
+
     # Run core tests first
     for test_func in "${core_test_functions[@]}"; do
         echo ""
-        if $test_func; then
-            tests_passed=$((tests_passed + 1))
+        local test_result=0
+        ${test_func} || test_result=$?
+
+        # Track which users failed this test
+        for failed_user in "${LAST_TEST_FAILED_USERS[@]}"; do
+            user_failures["${failed_user}"]=$((user_failures["${failed_user}"] + 1))
+        done
+
+        if [[ ${test_result} -eq 0 ]]; then
+            tests_passed=$((tests_passed + 5))  # All 5 users passed
         else
-            tests_failed=$((tests_failed + 1))
+            local users_failed=${test_result}
+            local users_passed=$((5 - users_failed))
+            tests_passed=$((tests_passed + users_passed))
+            tests_failed=$((tests_failed + users_failed))
+
             # Mark critical failure for authentication and file operation tests
-            if [[ "$test_func" == "test_kerberos_authentication" || "$test_func" == "test_file_operations" ]]; then
+            if [[ "${test_func}" == "test_kerberos_authentication" ]] || [[ "${test_func}" == "test_file_operations" ]]; then
                 critical_failure=true
             fi
         fi
+
+        # Clear the last test failed users array
+        LAST_TEST_FAILED_USERS=()
     done
 
-    # Only run persistent storage test if core functionality is working
+    # Skip persistent storage test in normal run - use 'persistent' argument to test it
     echo ""
-    if [ "$critical_failure" = true ]; then
-        print_warning "Skipping persistent storage test due to critical failures in core functionality"
-        print_warning "Fix Kerberos authentication and file operations before testing persistence"
-    else
-        if test_persistent_storage; then
-            tests_passed=$((tests_passed + 1))
-        else
-            tests_failed=$((tests_failed + 1))
-        fi
-    fi
+    print_warning "Skipping persistent storage test (use './test.sh persistent' to run it)"
 
     # Cleanup
     cleanup_test_files
 
+    # Per-client summary
+    print_header "Per-Client Test Results"
+    local all_clients_passed=true
+    for user in "${USERS[@]}"; do
+        local user_failed_count=${user_failures["${user}"]}
+        if [[ ${user_failed_count} -eq 0 ]]; then
+            print_success "${user}: ALL TESTS PASSED ✓"
+        else
+            print_error "${user}: ${user_failed_count}/${#core_test_functions[@]} tests FAILED ✗"
+            all_clients_passed=false
+        fi
+    done
+
     # Final results
     print_header "Test Results Summary"
-    echo "Tests passed: $tests_passed"
-    echo "Tests failed: $tests_failed"
+    echo "Tests passed: ${tests_passed}"
+    echo "Tests failed: ${tests_failed}"
     echo "Total tests: $((tests_passed + tests_failed))"
 
-    if [ $tests_failed -eq 0 ]; then
+    if [[ ${tests_failed} -eq 0 ]]; then
         print_success "All tests PASSED! 🎉"
         echo ""
         echo "Your NFS Kerberos POC is working correctly:"
@@ -344,39 +933,57 @@ run_all_tests() {
 }
 
 # Main execution
-if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
     echo "NFS Kerberos POC Test Suite"
     echo ""
-    echo "Usage: $0 [options]"
+    echo "Usage: ${0} [options] [test_name]"
     echo ""
     echo "Options:"
     echo "  --help, -h     Show this help message"
     echo "  --wait         Wait for pods to be ready before testing"
+    echo "  persistent     Run only persistent storage tests"
+    echo "  renewal        Run Kerberos renewal lifecycle test (~2 hours)"
     echo ""
     echo "Test functions (can be run individually):"
-    echo "  test_service_health        - Test KDC, NFS, and GSS services"
-    echo "  test_nri_integration       - Test NRI hook integration (when using NRI)"
     echo "  test_pod_status           - Test Kubernetes pod status"
+    echo "  test_non_root_user        - Test that containers run as non-root users"
     echo "  test_kerberos_authentication - Test Kerberos ticket acquisition"
     echo "  test_nfs_mount_access     - Test NFS mount accessibility"
     echo "  test_file_operations      - Test file create/read/write operations"
     echo "  test_persistent_storage   - Test data persistence across pod restarts"
+    echo "  test_kerberos_renewal_lifecycle - Test complete renewal lifecycle"
     echo "  cleanup_test_files        - Clean up test files"
     echo ""
-    echo "Example: $0 test_nfs_mount_access"
+    echo "Note: Infrastructure checks (KDC, NFS, GSS services) are available in status.sh"
+    echo ""
+    echo "Example: ${0} test_nfs_mount_access"
     exit 0
 fi
 
-if [ "${1:-}" = "--wait" ]; then
+if [[ "${1:-}" == "--wait" ]]; then
     wait_for_pods
     shift
 fi
 
+# Handle persistent storage test
+if [[ "${1:-}" == "persistent" ]]; then
+    echo "Running persistent storage tests only"
+    test_persistent_storage
+    exit $?
+fi
+
+# Handle Kerberos renewal lifecycle test
+if [[ "${1:-}" == "renewal" ]]; then
+    echo "Running Kerberos renewal lifecycle test"
+    test_kerberos_renewal_lifecycle
+    exit $?
+fi
+
 # If a specific test function is provided, run only that
-if [ $# -eq 1 ] && declare -f "$1" > /dev/null; then
-    echo "Running specific test: $1"
-    $1
+if [[ $# -eq 1 ]] && declare -f "${1}" > /dev/null; then
+    echo "Running specific test: ${1}"
+    ${1}
 else
-    # Run all tests
+    # Run all tests (excluding persistent storage by default)
     run_all_tests
 fi

--- a/vm-scripts/cleanup-nfs-kerberos.sh
+++ b/vm-scripts/cleanup-nfs-kerberos.sh
@@ -24,7 +24,6 @@ print_yellow "Starting NFS and Kerberos cleanup..."
 # Stop and clean up local NFS/Kerberos processes
 print_yellow "Stopping local Kerberos and NFS processes..."
 sudo pkill -f rpc.gssd || true
-sudo pkill -f kcm || true
 sudo umount /var/lib/nfs/rpc_pipefs 2>/dev/null || true
 
 # Stop NFS and Kerberos services

--- a/vm-scripts/install-kdc.sh
+++ b/vm-scripts/install-kdc.sh
@@ -68,8 +68,8 @@ cat > /etc/krb5.conf <<EOF
     proxiable = true
     dns_lookup_realm = false
     dns_lookup_kdc = false
-    ticket_lifetime = 24h
-    renew_lifetime = 7d
+    ticket_lifetime = 10m
+    renew_lifetime = 30m
     rdns = false
 
 [realms]
@@ -81,8 +81,8 @@ cat > /etc/krb5.conf <<EOF
         acl_file = /etc/krb5kdc/kadm5.acl
         key_stash_file = /etc/krb5kdc/stash
         kdc_ports = 750,88
-        max_life = 10h 0m 0s
-        max_renewable_life = 7d 0h 0m 0s
+        max_life = 20m 0s
+        max_renewable_life = 40m 0s
         master_key_type = des3-hmac-sha1
         supported_enctypes = aes256-cts:normal aes128-cts:normal des3-hmac-sha1:normal arcfour-hmac:normal
     }
@@ -120,10 +120,8 @@ print_yellow "Creating KDC database..."
 printf '%s\n%s\n' "${KDC_PASSWORD}" "${KDC_PASSWORD}" | kdb5_util create -s
 
 # Start KDC services
-systemctl enable krb5-kdc
-systemctl enable krb5-admin-server
-systemctl start krb5-kdc
-systemctl start krb5-admin-server
+systemctl enable --now krb5-kdc
+systemctl enable --now krb5-admin-server
 
 # Create admin principal
 print_yellow "Creating admin principal..."

--- a/vm-scripts/install-nfs.sh
+++ b/vm-scripts/install-nfs.sh
@@ -101,17 +101,17 @@ echo "Shared NFS directory with Kerberos authentication" > /exports/shared/readm
 # Configure NFS exports with Kerberos
 cat > /etc/exports <<EOF
 # NFSv4 root
-/exports *(rw,sync,no_subtree_check,no_root_squash,fsid=0,sec=sys:krb5:krb5i:krb5p)
+/exports *(rw,sync,no_subtree_check,fsid=0,sec=sys:krb5:krb5i:krb5p)
 
 # Shared directory - accessible by all authenticated users
-/exports/shared *(rw,sync,no_subtree_check,no_root_squash,sec=sys:krb5:krb5i:krb5p)
+/exports/shared *(rw,sync,no_subtree_check,sec=sys:krb5:krb5i:krb5p)
 EOF
 
 # Add user home directory exports dynamically
 for user in "${USERS[@]}"; do
     cat >> /etc/exports <<EOF
 # User home directory for ${user}
-/exports/home/${user} *(rw,sync,no_subtree_check,no_root_squash,sec=sys:krb5:krb5i:krb5p)
+/exports/home/${user} *(rw,sync,no_subtree_check,sec=sys:krb5:krb5i:krb5p)
 EOF
 done
 


### PR DESCRIPTION
Make all fo the nfs client use different setup, so see what works and what does not.

Rewrite the ./test.sh to actually test things nicely.

Make ticket lifetime very short, for testing purposes. Fix issues that arise from this in renewal process.